### PR TITLE
feat: add icon and loading support to <Button />

### DIFF
--- a/example/src/ButtonExample.js
+++ b/example/src/ButtonExample.js
@@ -10,9 +10,13 @@ import {
   Button,
 } from 'react-native-paper';
 
-export default class ButtonsExample extends Component {
+export default class ButtonExample extends Component {
 
   static title = 'Button';
+
+  state = {
+    loading: true,
+  };
 
   render() {
     return (
@@ -38,6 +42,18 @@ export default class ButtonsExample extends Component {
             Custom
           </Button>
         </View>
+        <View style={styles.row}>
+          <Button icon='add-a-photo'>Icon</Button>
+          <Button
+            raised
+            primary
+            icon='file-download'
+            loading={this.state.loading}
+            onPress={() => this.setState(state => ({ loading: !state.loading }))}
+          >
+            Loading
+          </Button>
+        </View>
       </View>
     );
   }
@@ -51,6 +67,7 @@ const styles = StyleSheet.create({
 
   row: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     alignItems: 'center',
   },
 

--- a/example/src/ButtonExample.js
+++ b/example/src/ButtonExample.js
@@ -54,6 +54,16 @@ export default class ButtonExample extends Component {
             Loading
           </Button>
         </View>
+        <View style={styles.row}>
+          <Button disabled icon='my-location'>Disabled</Button>
+          <Button
+            disabled
+            loading
+            raised
+          >
+            Loading
+          </Button>
+        </View>
       </View>
     );
   }
@@ -61,7 +71,8 @@ export default class ButtonExample extends Component {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: Colors.white,
+    flex: 1,
+    backgroundColor: Colors.grey200,
     padding: 8,
   },
 

--- a/example/src/ExampleList.js
+++ b/example/src/ExampleList.js
@@ -14,14 +14,14 @@ import CardExample from './CardExample';
 import RippleExample from './RippleExample';
 import PaperExample from './PaperExample';
 import TextExample from './TextExample';
-import ButtonsExample from './ButtonsExample';
+import ButtonExample from './ButtonExample';
 
 export const examples = {
   ripple: RippleExample,
   paper: PaperExample,
   text: TextExample,
   card: CardExample,
-  button: ButtonsExample,
+  button: ButtonExample,
 };
 
 export default class ExampleList extends Component {

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -26,6 +26,7 @@ type DefaultProps = {
 }
 
 type Props = {
+  disabled?: boolean;
   raised?: boolean;
   primary?: boolean;
   dark?: boolean;
@@ -44,6 +45,7 @@ type State = {
 
 class Button extends Component<DefaultProps, Props, State> {
   static propTypes = {
+    disabled: PropTypes.bool,
     raised: PropTypes.bool,
     primary: PropTypes.bool,
     dark: PropTypes.bool,
@@ -89,6 +91,8 @@ class Button extends Component<DefaultProps, Props, State> {
 
   render() {
     const {
+      disabled,
+      raised,
       primary,
       dark,
       loading,
@@ -100,47 +104,75 @@ class Button extends Component<DefaultProps, Props, State> {
       theme,
     } = this.props;
     const { colors } = theme;
-    const backgroundColor = primary ? colors.primary : white;
     const fontFamily = theme.fonts.medium;
-    const isDark = typeof dark === 'boolean' ? dark : !color(backgroundColor).light();
-    const textColor = isDark ? white : black;
+
+    let backgroundColor, textColor, isDark;
+
+    if (disabled) {
+      backgroundColor = raised ? 'rgba(0, 0, 0, .12)' : 'transparent';
+    } else {
+      if (primary) {
+        backgroundColor = colors.primary;
+      } else {
+        backgroundColor = raised ? white : 'transparent';
+      }
+    }
+
+    if (typeof dark === 'boolean') {
+      isDark = dark;
+    } else {
+      isDark = backgroundColor === 'transparent' ? false : !color(backgroundColor).light();
+    }
+
+    if (disabled) {
+      textColor = 'rgba(0, 0, 0, .26)';
+    } else {
+      textColor = isDark ? white : black;
+    }
+
     const rippleColor = color(textColor).alpha(0.32).rgbaString();
     const buttonStyle = { backgroundColor, borderRadius: roundness };
     const touchableStyle = { borderRadius: roundness };
     const textStyle = { color: textColor, fontFamily };
 
+    const content = (
+      <View style={styles.content}>
+        {icon && loading !== true ?
+          <Icon
+            name={icon}
+            size={16}
+            color={textColor}
+            style={styles.icon}
+          /> : null
+        }
+        {loading ?
+          <ActivityIndicator
+            size='small'
+            color={textColor}
+            style={styles.icon}
+          /> : null
+        }
+        <Text style={[ styles.label, textStyle, { fontFamily } ]}>
+          {children ? children.toUpperCase() : ''}
+        </Text>
+      </View>
+    );
+
     return (
-      <AnimatedPaper elevation={this.state.elevation} style={[ styles.button, buttonStyle, style ]}>
-        <TouchableRipple
-          borderless
-          delayPressIn={0}
-          onPress={onPress}
-          onPressIn={this._handlePressIn}
-          onPressOut={this._handlePressOut}
-          rippleColor={rippleColor}
-          style={touchableStyle}
-        >
-          <View style={styles.content}>
-            {icon && loading !== true ?
-              <Icon
-                name={icon}
-                size={16}
-                color={textColor}
-                style={styles.icon}
-              /> : null
-            }
-            {loading ?
-              <ActivityIndicator
-                size='small'
-                color={textColor}
-                style={styles.icon}
-              /> : null
-            }
-            <Text style={[ styles.label, textStyle, { fontFamily } ]}>
-              {children ? children.toUpperCase() : ''}
-            </Text>
-          </View>
-        </TouchableRipple>
+      <AnimatedPaper elevation={disabled ? 0 : this.state.elevation} style={[ styles.button, buttonStyle, style ]}>
+        {disabled ? content :
+          <TouchableRipple
+            borderless
+            delayPressIn={0}
+            onPress={onPress}
+            onPressIn={this._handlePressIn}
+            onPressOut={this._handlePressOut}
+            rippleColor={rippleColor}
+            style={touchableStyle}
+          >
+            {content}
+          </TouchableRipple>
+        }
       </AnimatedPaper>
     );
   }

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -84,7 +84,7 @@ class Button extends Component<DefaultProps, Props, State> {
     if (this.props.raised) {
       Animated.timing(this.state.elevation, {
         toValue: 2,
-        duration: 200,
+        duration: 150,
       }).start();
     }
   };

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -6,10 +6,12 @@ import React, {
   PropTypes,
 } from 'react';
 import {
+  ActivityIndicator,
   Animated,
   View,
   StyleSheet,
 } from 'react-native';
+import Icon from './Icon';
 import Paper from './Paper';
 import Text from './Typography/Text';
 import TouchableRipple from './TouchableRipple';
@@ -20,8 +22,6 @@ import type { Theme } from '../types/Theme';
 const AnimatedPaper = Animated.createAnimatedComponent(Paper);
 
 type DefaultProps = {
-  raised: boolean;
-  primary: boolean;
   roundness: number;
 }
 
@@ -29,7 +29,9 @@ type Props = {
   raised?: boolean;
   primary?: boolean;
   dark?: boolean;
+  loading?: boolean;
   roundness?: number;
+  icon?: string;
   children?: string;
   onPress?: Function;
   style?: any;
@@ -45,7 +47,9 @@ class Button extends Component<DefaultProps, Props, State> {
     raised: PropTypes.bool,
     primary: PropTypes.bool,
     dark: PropTypes.bool,
+    loading: PropTypes.bool,
     roundness: PropTypes.number,
+    icon: PropTypes.string,
     children: PropTypes.string.isRequired,
     onPress: PropTypes.func,
     style: View.propTypes.style,
@@ -53,8 +57,6 @@ class Button extends Component<DefaultProps, Props, State> {
   };
 
   static defaultProps = {
-    raised: false,
-    primary: false,
     roundness: 2,
   };
 
@@ -89,7 +91,9 @@ class Button extends Component<DefaultProps, Props, State> {
     const {
       primary,
       dark,
+      loading,
       roundness,
+      icon,
       children,
       onPress,
       style,
@@ -103,6 +107,7 @@ class Button extends Component<DefaultProps, Props, State> {
     const rippleColor = color(textColor).alpha(0.32).rgbaString();
     const buttonStyle = { backgroundColor, borderRadius: roundness };
     const touchableStyle = { borderRadius: roundness };
+    const textStyle = { color: textColor, fontFamily };
 
     return (
       <AnimatedPaper elevation={this.state.elevation} style={[ styles.button, buttonStyle, style ]}>
@@ -115,9 +120,26 @@ class Button extends Component<DefaultProps, Props, State> {
           rippleColor={rippleColor}
           style={touchableStyle}
         >
-          <Text style={[ styles.label, { fontFamily, color: textColor } ]}>
-            {children ? children.toUpperCase() : ''}
-          </Text>
+          <View style={styles.content}>
+            {icon && loading !== true ?
+              <Icon
+                name={icon}
+                size={16}
+                color={textColor}
+                style={styles.icon}
+              /> : null
+            }
+            {loading ?
+              <ActivityIndicator
+                size='small'
+                color={textColor}
+                style={styles.icon}
+              /> : null
+            }
+            <Text style={[ styles.label, textStyle, { fontFamily } ]}>
+              {children ? children.toUpperCase() : ''}
+            </Text>
+          </View>
         </TouchableRipple>
       </AnimatedPaper>
     );
@@ -128,6 +150,16 @@ const styles = StyleSheet.create({
   button: {
     margin: 8,
     minWidth: 88,
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+  },
+  icon: {
+    width: 16,
+    marginLeft: 12,
+    marginRight: -4,
   },
   label: {
     textAlign: 'center',

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -65,7 +65,7 @@ class Card extends Component<DefaultProps, Props, State> {
   _handlePressOut = () => {
     Animated.timing(this.state.elevation, {
       toValue: this.props.elevation,
-      duration: 200,
+      duration: 150,
     }).start();
   };
 


### PR DESCRIPTION
GIF says a thousand words

![button](https://cloud.githubusercontent.com/assets/1174278/20227220/73e48250-a871-11e6-8574-a38235e68441.gif)

We probably need a custom loading indicator for iOS, but that's out of scope for this PR

![image](https://cloud.githubusercontent.com/assets/1174278/20227379/1976fe46-a872-11e6-848d-a370016ec856.png)
