### PR TITLE
feat: support theme overrides for themed components

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -87,7 +87,7 @@ class Card extends Component<DefaultProps, Props, State> {
 
     const { roundness } = theme;
     const total = Children.count(children);
-    const siblings = Children.map(children, child => child.type.name);
+    const siblings = Children.map(children, child => child.type.displayName);
 
     return (
       <AnimatedPaper elevation={this.state.elevation} style={[ styles.card, { borderRadius: roundness }, style ]}>

--- a/src/components/Card/CardContent.js
+++ b/src/components/Card/CardContent.js
@@ -15,7 +15,7 @@ type Props = {
 
 const CardContent = (props: Props) => {
   const { index, total, siblings, style } = props;
-  const cover = 'CardCover';
+  const cover = 'withTheme(CardCover)';
 
   let contentStyle, prev, next;
 

--- a/src/core/ThemeProvider.js
+++ b/src/core/ThemeProvider.js
@@ -6,14 +6,27 @@ import {
   Children,
 } from 'react';
 import DefaultTheme from '../styles/DefaultTheme';
+import type { Theme } from '../types/Theme';
+
+type DefaultProps = {
+  theme: Theme
+}
+
+type Props = {
+  children?: any;
+  theme?: Theme
+}
 
 export const theme = 'react-native-paper$theme';
 
-export default class ThemeProvider extends PureComponent {
-
+export default class ThemeProvider extends PureComponent<DefaultProps, Props, void> {
   static propTypes = {
     children: PropTypes.node.isRequired,
     theme: PropTypes.object,
+  };
+
+  static defaultProps = {
+    theme: DefaultTheme,
   };
 
   static childContextTypes = {
@@ -22,7 +35,7 @@ export default class ThemeProvider extends PureComponent {
 
   getChildContext() {
     return {
-      [theme]: this.props.theme || DefaultTheme,
+      [theme]: this.props.theme,
     };
   }
 


### PR DESCRIPTION
For example, this will allow you to do `<Button theme={{ roundess: 3 }}>Hello world</Button>`