### PR TITLE
docs: enable JavaScript in documentation

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,11 +4,13 @@
   "description": "Documentation for React Native Paper",
   "private": true,
   "scripts": {
-    "build": "babel-node index",
+    "dev": "babel-node index",
+    "build": "babel-node index build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
     "glamor": "^2.19.0",
+    "quik": "^0.11.1",
     "react": "~15.3.2",
     "react-dom": "~15.3.0"
   },

--- a/docs/templates/HTML.js
+++ b/docs/templates/HTML.js
@@ -33,9 +33,7 @@ export default function HTML({ title, description, body, css }: Props) {
 
         <style type='text/css' dangerouslySetInnerHTML={{ __html: css }} />
       </head>
-      <body>
-        <div id='root' dangerouslySetInnerHTML={{ __html: body }} />
-      </body>
+      <body dangerouslySetInnerHTML={{ __html: body }} />
     </html>
   );
 }

--- a/docs/templates/Page.js
+++ b/docs/templates/Page.js
@@ -49,7 +49,7 @@ export default function Body({ url, pages, children }: any) {
   return (
     <div {...wrapper}>
       <nav {...sidebar}>
-        <a href='index.html' {...mono} {...link} {...(url.pathname === '/' ? active : null)}>
+        <a href='index.html' {...mono} {...link} {...(url.pathname === '/index' ? active : null)}>
           Home
         </a>
         <hr {...separator} />


### PR DESCRIPTION
This takes care of generating static HTML files as well as JavaScript bundles. This will allow us to use JavaScript in documentation pages, as well as faster development time since you just have to reload the page instead of building all the documentation again.

Hot reloading is a little slow and doesn't work for functional components right now, but I'll need to work on that in `quik`.