### PR TITLE
feat: add checkbox and radio animations on Android

### DIFF
--- a/example/src/CheckboxExample.js
+++ b/example/src/CheckboxExample.js
@@ -33,7 +33,7 @@ export default class CheckboxExample extends Component {
         <View style={styles.row}>
           <Paragraph>Custom</Paragraph>
           <Checkbox
-            color={Colors.pink500}
+            color={Colors.blue500}
             checked={this.state.checkedCustom}
             onPress={() => this.setState(state => ({ checkedCustom: !state.checkedCustom }))}
           />

--- a/example/src/RadioButtonExample.js
+++ b/example/src/RadioButtonExample.js
@@ -33,7 +33,7 @@ export default class RadioButtonExample extends Component {
         <View style={styles.row}>
           <Paragraph>Custom</Paragraph>
           <RadioButton
-            color={Colors.pink500}
+            color={Colors.blue500}
             checked={this.state.checkedCustom}
             onPress={() => this.setState(state => ({ checkedCustom: !state.checkedCustom }))}
           />

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -2,12 +2,15 @@
 
 import React, {
   PropTypes,
+  Component,
 } from 'react';
 import {
+  Animated,
+  View,
+  Platform,
   StyleSheet,
 } from 'react-native';
 import color from 'color';
-import Icon from './Icon';
 import TouchableRipple from './TouchableRipple';
 import withTheme from '../core/withTheme';
 import type { Theme } from '../types/Theme';
@@ -20,77 +23,131 @@ type Props = {
   theme: Theme;
 }
 
+type State = {
+  borderAnim: Animated.Value;
+  radioAnim: Animated.Value;
+}
+
+const BORDER_WIDTH = 2;
+
 /**
  * Radio buttons allow the selection of a single option from a set
  */
-const RadioButton = (props: Props) => {
-  const {
-    checked,
-    disabled,
-    onPress,
-    theme,
-  } = props;
+class RadioButton extends Component <void, Props, State> {
+  static propTypes = {
+    /**
+     * Whether radio is checked
+     */
+    checked: PropTypes.bool.isRequired,
+    /**
+     * Whether radio is disabled
+     */
+    disabled: PropTypes.bool,
+    /**
+     * Function to execute on press
+     */
+    onPress: PropTypes.func,
+    /**
+     * Custom color for radio
+     */
+    color: PropTypes.string,
+    theme: PropTypes.object.isRequired,
+  };
 
-  const radioColor = props.color || theme.colors.primary;
+  state = {
+    borderAnim: new Animated.Value(BORDER_WIDTH),
+    radioAnim: new Animated.Value(1),
+  };
 
-  let rippleColor, radioStyle;
-
-  if (disabled) {
-    rippleColor = 'rgba(0, 0, 0, .16)';
-    radioStyle = { color: 'rgba(0, 0, 0, .26)' };
-  } else {
-    rippleColor = color(radioColor).clearer(0.32).rgbaString();
-    if (checked) {
-      radioStyle = { color: radioColor };
+  componentWillReceiveProps(nextProps: Props) {
+    if (nextProps.checked !== this.props.checked) {
+      if (Platform.OS === 'android') {
+        if (nextProps.checked) {
+          this.state.radioAnim.setValue(1.2);
+          Animated.timing(this.state.radioAnim, {
+            toValue: 1,
+            duration: 150,
+          }).start();
+        } else {
+          this.state.borderAnim.setValue(10);
+          Animated.timing(this.state.borderAnim, {
+            toValue: BORDER_WIDTH,
+            duration: 150,
+          }).start();
+        }
+      }
     }
   }
 
-  return (
-    <TouchableRipple
-      {...props}
-      borderless
-      rippleColor={rippleColor}
-      onPress={disabled ? undefined : onPress}
-      style={styles.container}
-    >
-      <Icon
-        name={checked ? 'radio-button-checked' : 'radio-button-unchecked'}
-        size={24}
-        style={[ styles.radio, radioStyle ]}
-      />
-    </TouchableRipple>
-  );
-};
+  render() {
+    const {
+      disabled,
+      onPress,
+      checked,
+      theme,
+    } = this.props;
 
-RadioButton.propTypes = {
-  /**
-   * Whether radio is checked
-   */
-  checked: PropTypes.bool.isRequired,
-  /**
-   * Whether radio is disabled
-   */
-  disabled: PropTypes.bool,
-  /**
-   * Function to execute on press
-   */
-  onPress: PropTypes.func,
-  /**
-   * Custom color for radio
-   */
-  color: PropTypes.string,
-  theme: PropTypes.object.isRequired,
-};
+    const checkedColor = this.props.color || theme.colors.accent;
+    const uncheckedColor = 'rgba(0, 0, 0, .54)';
+
+    let rippleColor, radioColor;
+
+    if (disabled) {
+      rippleColor = 'rgba(0, 0, 0, .16)';
+      radioColor = 'rgba(0, 0, 0, .26)';
+    } else {
+      rippleColor = color(checkedColor).clearer(0.32).rgbaString();
+      radioColor = checked ? checkedColor : uncheckedColor;
+    }
+
+    return (
+      <TouchableRipple
+        {...this.props}
+        borderless
+        rippleColor={rippleColor}
+        onPress={disabled ? undefined : onPress}
+        style={styles.container}
+      >
+        <Animated.View style={[ styles.radio, { borderColor: radioColor, borderWidth: this.state.borderAnim } ]}>
+          {this.props.checked ?
+            <View style={[ StyleSheet.absoluteFill, styles.radioContainer ]}>
+              <Animated.View
+                style={[
+                  styles.dot,
+                  {
+                    backgroundColor: radioColor,
+                    transform: [ { scale: this.state.radioAnim } ],
+                  },
+                ]}
+              />
+            </View> : null}
+        </Animated.View>
+      </TouchableRipple>
+    );
+  }
+}
 
 const styles = StyleSheet.create({
   container: {
     borderRadius: 18,
   },
 
+  radioContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
   radio: {
-    /* FIXME: using opacity doesn't work properly with TouchableHighlight */
-    color: 'rgba(0, 0, 0, .54)',
-    margin: 6,
+    height: 20,
+    width: 20,
+    borderRadius: 10,
+    margin: 8,
+  },
+
+  dot: {
+    height: 10,
+    width: 10,
+    borderRadius: 5,
   },
 });
 


### PR DESCRIPTION
Border animations aren't very nice on iOS, so I disabled animations on iOS for now. Let's add animations when we find a better way.
Also native animations don't support borders as of now, so can't enables native animations either, probably can enable in future