### PR TITLE
Removed 'export * as' syntax in 'src/index.js'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 /* @flow */
 
+import * as Colors from './styles/colors';
+export { Colors };
+
 export { default as withTheme } from './core/withTheme';
 export { default as ThemeProvider } from './core/ThemeProvider';
 export { default as Provider } from './core/Provider';
 export { default as DefaultTheme } from './styles/DefaultTheme';
-
-import * as Colors from './styles/colors';
-export { Colors };
 
 export { default as Button } from './components/Button';
 export { default as Card } from './components/Card';

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@ export { default as withTheme } from './core/withTheme';
 export { default as ThemeProvider } from './core/ThemeProvider';
 export { default as Provider } from './core/Provider';
 
-export * as Colors from './styles/colors';
+import * as Colors from './styles/colors';
+export { Colors };
 
 export { default as Button } from './components/Button';
 export { default as Card } from './components/Card';


### PR DESCRIPTION
Since `export * as ...` requires addition of a custom preset, `react-native-stage-0` or `transform-export-extensions` in `.babelrc`.

Fixes #91.