### PR TITLE
fix: use `flexGrow` instead of `flex` to avoid collapsing

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -98,7 +98,7 @@ class Card extends Component<DefaultProps, Props, State> {
           onPressOut={onPress ? this._handlePressOut : undefined}
           style={styles.container}
         >
-          <View style={styles.container}>
+          <View>
             {Children.map(children, (child, index) =>
               React.cloneElement(child, {
                 index,

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -98,7 +98,7 @@ class Card extends Component<DefaultProps, Props, State> {
           onPressOut={onPress ? this._handlePressOut : undefined}
           style={styles.container}
         >
-          <View>
+          <View style={styles.innerContainer}>
             {Children.map(children, (child, index) =>
               React.cloneElement(child, {
                 index,
@@ -121,6 +121,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  innerContainer: {
+    flexGrow: 1,
+  }
 });
 
 export default withTheme(Card);


### PR DESCRIPTION
Code from the example project wasn't working properly. The Card wasn't getting displayed. Fixed by removing flex: 1 from a View inside a TouchableWithoutFeedback.

Fixes #94.